### PR TITLE
Report correct rank for matmul and aggregrations

### DIFF
--- a/src/ops.jl
+++ b/src/ops.jl
@@ -3,9 +3,11 @@ import Base: +, -, *, /
 for (op,fn) in zip((:+, :-, :/, :*), (atg_add, atg_sub, atg_div, atg_matmul))
   @eval function $op(t1::Tensor{T,N}, t2::Tensor{T,K}) where {T,N,K}
     ptr = Ref(Ptr{Cvoid}())
+    rank = Ref{Cint}(-1)
 
     $fn(ptr, t1.ptr, t2.ptr)
-    Tensor{T,N}(ptr[], on(t1))
+    at_dim(rank, ptr[])
+    Tensor{T,rank[]}(ptr[], on(t1))
   end
 end
 

--- a/src/statistics.jl
+++ b/src/statistics.jl
@@ -5,11 +5,11 @@ function Statistics.mean(t::Tensor{T,N}; dims = :) where {T,N}
 
   if dims isa Colon
     atg_mean(ptr, t.ptr, options[T])
+    Tensor{T,0}(ptr[], on(t))
   else
     atg_mean1(ptr, t.ptr, dims, length(dims), dims[1], options[T])
+    Tensor{T,N-length(dims)}(ptr[], on(t))
   end
-
-  Tensor{T,N}(ptr[], on(t))
 end
 
 function Statistics.sum(t::Tensor{T,N}; dims = :) where {T,N}
@@ -17,9 +17,9 @@ function Statistics.sum(t::Tensor{T,N}; dims = :) where {T,N}
 
   if dims isa Colon
     atg_sum(ptr, t.ptr, options[T])
+    Tensor{T,0}(ptr[], on(t))
   else
     atg_sum1(ptr, t.ptr, dims, length(dims), dims[1], options[T])
+    Tensor{T,N-length(dims)}(ptr[], on(t))
   end
-
-  Tensor{T,N}(ptr[], on(t))
 end


### PR DESCRIPTION
`display` and similar functions were failing because the original dimensions were maintained in the type instead of the new (usually reduced) output dimensions.