### PR TITLE
Limit compat of Torch_jll to v1.4

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,6 +17,7 @@ ZygoteRules = "700de1a5-db45-46bc-99cf-38207098b444"
 FillArrays = "0.8, 0.11, 0.13"
 NNlib = "0.6, 0.7"
 Requires = "1"
+Torch_jll = "~1.4"
 ZygoteRules = "0"
 julia = "1.4"
 


### PR DESCRIPTION
To avoid breaking change when Torch_jll v1.10.2 is registered in the General registry, as Torch_jll v1.10.2 does not include the C wrapper.